### PR TITLE
Use bluebird built in defer to implement & direct expose superagent

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,9 @@
 
 var Promise = require("bluebird");
 
-var Request = require("superagent").Request;
+// sometime we just want `var request = require('superagent-bluebird-promise')`
+var superagent = module.exports = require('superagent');
+var Request = superagent.Request;
 
 /**
  * @namespace utils

--- a/index.js
+++ b/index.js
@@ -19,22 +19,7 @@ var Request = require("superagent").Request;
  * @return {Bluebird.Promise}
  */
 Request.prototype.promise = function() {
-  var self = this;
-  return new Promise(function(resolve, reject) {
-      self.end(function(err, res) {
-        if (typeof res != 'undefined' && res.status >= 400) {
-          reject({
-            status: res.status,
-            res: res,
-            error: res.error
-          });
-        } else if (err) {
-          reject({
-            error: err
-          });
-        } else {
-          resolve(res);
-        }
-      });
-    });
+  var defer = Promise.defer();
+  this.end(defer.callback);
+  return defer.promise;
 };


### PR DESCRIPTION
1. Use bluebird built in defer to implement
2. direct expose superagent

I think should not care the return status code for user. 
And code like 
```js
Promise.reject({
    err: error
})
```
will result `Possibly unhandled Error: [object Object]` , and we got no idea to deal what's going on . 
So I believe leave the original error like `Promise.reject(error)` may be better,and defer can do.