### PR TITLE
Reject with reason an instanceof Error

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,15 +25,15 @@ Request.prototype.promise = function() {
   return new Promise(function(resolve, reject) {
       self.end(function(err, res) {
         if (typeof res != 'undefined' && res.status >= 400) {
-          reject({
+          reject(new Error({
             status: res.status,
             res: res,
             error: res.error
-          });
+          }));
         } else if (err) {
-          reject({
+          reject(new Error({
             error: err
-          });
+          }));
         } else {
           resolve(res);
         }


### PR DESCRIPTION
For debugging purposes, it is useful to make reason an instanceof Error

cf. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/reject http://making.change.org/post/69613524472/promises-and-error-handling

Note that all https://github.com/petkaantonov/bluebird code examples also reject reasons being instanceof Error.

Cheers