### PR TITLE
Always return cancellable promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,34 +30,18 @@ An error is thrown for all HTTP errors and responses that have a response code o
 
 The `error` parameter always has a key `error` and for 4xx and 5xx responses, will also have a `status` and `res` key.
 
-## Options
+## Cancelling requests
 
-```js
-var promise = request.get('/an-endpoint').promise([options]);
-```
-
-### options.cancellable (boolean)
-
-```js
-var promise = request.get('/an-endpoint').promise({ cancellable: true });
-
-```
-
-#### Cancelling promises
+You can [abort the request](http://visionmedia.github.io/superagent/#aborting-requests) by [cancelling the promise](https://github.com/petkaantonov/bluebird/blob/master/API.md#cancelerror-reason---promise):
 
 ```js
 promise.cancel();
 ```
 
-#### Cancelling promises with a custom reason
+When aborting the request with a [custom reason](https://github.com/petkaantonov/bluebird/blob/master/API.md#cancelerror-reason---promise), make sure your error class inherits from Bluebird's [CancellationError class](https://github.com/petkaantonov/bluebird/blob/master/API.md#cancellationerror) or the request won't be aborted.
 
-**IMPORTANT:** The superagent request won't be [aborted](http://visionmedia.github.io/superagent/#aborting-requests) unless the custom reason class extends bluebird's [CancellationError](https://github.com/petkaantonov/bluebird/blob/master/API.md#cancellationerror).
+This functionality is only possible because all promises returned from `.promise()` calls are [cancellable](https://github. com/petkaantonov/bluebird/blob/master/API.md#cancellable---promise). To disable this functionality, call Bluebird's [uncancellable](https://github.com/petkaantonov/bluebird/blob/master/API.md#uncancellable---promise) method on the promise:
 
 ```js
-var Promise = require('bluebird');
-class CustomCancellationError extends Promise.CancellationError {
-  ...
-};
-
-promise.cancel(new CustomCancellationError());
+promise.uncancellable();
 ```

--- a/index.js
+++ b/index.js
@@ -28,15 +28,11 @@ SuperagentPromiseError.prototype.constructor = SuperagentPromiseError;
  * Call .promise() to return promise for the request
  *
  * @method promise
- * @params {object} [options] Options
- * @config {boolean} [cancellable=false] Return a cancellable promise
  * @return {Bluebird.Promise}
  */
-Request.prototype.promise = function(options) {
+Request.prototype.promise = function() {
   var req = this;
   var error;
-
-  options = options || { cancellable: false };
 
   var promise = new Promise(function(resolve, reject) {
       req.end(function(err, res) {
@@ -53,16 +49,12 @@ Request.prototype.promise = function(options) {
           resolve(res);
         }
       });
+    })
+    .cancellable()
+    .catch(Promise.CancellationError, function(err) {
+      req.abort();
+      throw err;
     });
-
-  if (options.cancellable) {
-    promise = promise
-      .cancellable()
-      .catch(Promise.CancellationError, function(e) {
-        req.abort();
-        throw e;
-    });
-  }
 
   return promise;
 };

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -84,7 +84,7 @@ describe 'superagent-promise', ->
 
       it 'should abort the request when the promise is cancelled', (done) ->
         request.get("localhost:3000/good")
-          .promise { cancellable: true }
+          .promise()
           .catch(->)
           .cancel()
 
@@ -97,7 +97,7 @@ describe 'superagent-promise', ->
         errorSpy = sinon.spy()
 
         request.get("localhost:3000/good")
-          .promise { cancellable: true }
+          .promise()
           .catch errorSpy
           .cancel()
 
@@ -113,7 +113,7 @@ describe 'superagent-promise', ->
 
       it 'should abort the request when the promise is cancelled', (done) ->
         request.get("localhost:3000/good")
-          .promise { cancellable: true }
+          .promise()
           .catch(->)
           .cancel new CustomCancellationError
 
@@ -126,7 +126,7 @@ describe 'superagent-promise', ->
         errorSpy = sinon.spy()
 
         request.get("localhost:3000/good")
-          .promise { cancellable: true }
+          .promise()
           .catch errorSpy
           .cancel new CustomCancellationError
 


### PR DESCRIPTION
The conversation in https://github.com/KyleAMathews/superagent-bluebird-promise/issues/15 made me rethink the idea of making cancellable promises the default, and deprecating the use of `.promise({ cancellable: true })`.

It's possibly a controversial change, and would require a major version bump, but I think it makes a lot of sense. This greatly simplifies the API and makes request cancellation a sensible default rather than an advanced feature.

What are your thoughts on this? cc @bergus @jxm262