### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ promise.cancel();
 
 When aborting the request with a [custom reason](https://github.com/petkaantonov/bluebird/blob/master/API.md#cancelerror-reason---promise), make sure your error class inherits from Bluebird's [CancellationError class](https://github.com/petkaantonov/bluebird/blob/master/API.md#cancellationerror) or the request won't be aborted.
 
-This is only possible because all promises are [cancellable](https://github. com/petkaantonov/bluebird/blob/master/API.md#cancellable---promise) by default. To disable this functionality, call Bluebird's [uncancellable](https://github.com/petkaantonov/bluebird/blob/master/API.md#uncancellable---promise) method on the promise:
+This is only possible because all promises are [cancellable](https://github.com/petkaantonov/bluebird/blob/master/API.md#cancellable---promise) by default. To disable this functionality, call Bluebird's [uncancellable](https://github.com/petkaantonov/bluebird/blob/master/API.md#uncancellable---promise) method on the promise:
 
 ```js
 promise.uncancellable();


### PR DESCRIPTION
Trivial whitespace in URL was causing a broken link. (Nice utiltily BTW. Thanks.)