### PR TITLE
Export SuperagentPromiseError so it can be caught

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,10 +8,10 @@ var Request = superagent.Request;
 
 // Create custom error type.
 // Create a new object, that prototypally inherits from the Error constructor.
-function SuperagentPromiseError(message) {
+var SuperagentPromiseError = superagent.SuperagentPromiseError = function (message) {
   this.name = 'SuperagentPromiseError';
   this.message = message || 'Bad request';
-}
+};
 
 SuperagentPromiseError.prototype = new Error();
 SuperagentPromiseError.prototype.constructor = SuperagentPromiseError;


### PR DESCRIPTION
Bluebird's [.catch()](https://github.com/petkaantonov/bluebird/blob/master/API.md#catchfunction-errorclassfunction-predicate-function-handler---promise) supports an error class, the prototype of which is matched against. Currently `SuperagentPromiseError` is only available as a local variable which prevents this idiomatic use. This patch fixes that by exporting the error class:

```javascript
var request                = require('superagent-bluebird-promise');
var SuperagentPromiseError = request.SuperagentPromiseError;

request('/api')
    .then(function (resource) {
        // resolved
    })
    .catch(SuperagentPromiseError, function (error) {
        // rejected
    });
```