### PR TITLE
Bluebird provides .caught() for this

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ Request.prototype.promise = function() {
       });
     })
     .cancellable()
-    ['catch'](Promise.CancellationError, function(err) {
+    .caught(Promise.CancellationError, function(err) {
       req.abort();
       throw err;
     });


### PR DESCRIPTION
From Bluebird's [API docs](https://github.com/petkaantonov/bluebird/blob/master/API.md#catchfunction-errorclassfunction-predicate-function-handler---promise):

> For compatibility with earlier ECMAScript version, an alias .caught() is provided for .catch().

This seems a bit less confusing in purpose than literal access with a string for YUI.