### PR TITLE
Add `catch` to Request prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,22 @@ Add promise support to
 `npm install superagent-bluebird-promise`
 
 ## Usage
-Simply require this package instead of `superagent`. Then you can call `.then()` instead of `.end()` to get a promise for your requests.
+Simply require this package instead of `superagent`. Then you can call `.then()` or `.catch()` instead of `.end()` to get a promise for your requests.
 
 ```javascript
 var request = require('superagent-bluebird-promise');
 
+// .then()
 request.get('/an-endpoint')
   .then(function(res) {
     console.log(res);
   }, function(error) {
+    console.log(error);
+  });
+
+// .catch()
+request.get('/an-endpoint')
+  .catch(function(error) {
     console.log(error);
   });
 ```

--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ Request.prototype.promise = function() {
 
 /**
  *
- * Make superagent requests Promises/A+ conformant
+ * Make superagent requests Promises ES6 conformant
  *
  * Call .then([onFulfilled], [onRejected]) to register callbacks
  *
@@ -94,4 +94,19 @@ Request.prototype.promise = function() {
 Request.prototype.then = function() {
   var promise = this.promise();
   return promise.then.apply(promise, arguments);
+};
+
+/**
+ *
+ * Make superagent requests Promises ES6 conformant
+ *
+ * Call .catch([onRejected]) to register callback
+ *
+ * @method catch
+ * @param {function} [onRejected]
+ * @return {Bluebird.Promise}
+ */
+Request.prototype.catch = function() {
+  var promise = this.promise();
+  return promise.catch.apply(promise, arguments);
 };

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -59,6 +59,12 @@ describe 'superagent-promise', ->
           .to.equal("cannot GET http://localhost:3000/not-found (404)")
         done()
 
+  it 'should expose a catch method on the request object', (done) ->
+    request.get("http://localhost:3000/not-found")
+      .catch (error) ->
+        expect(error).to.exist
+        done()
+
   it 'should reject an error object when there is an http error', ->
     request.get("localhost:23423")
       .then (res) ->


### PR DESCRIPTION
In our project, we've been tripped up a few times by the fact that the Request prototype doesn't have the standard `catch` promise method available.

To get around this, we've had to write `request.get(...).then().catch(function(error) { ... })` or `request.get(...).promise().catch(function(error) { ... })` instead, which is far from ideal.

This pull request adds `catch` to `Request.prototype`, so that the following code is valid:

```js
request.get(...).catch(function(error) { ... });
```

I propose that, for now, we draw the line at standard promise methods (`then` and `catch`), but we can revisit this decision in the future.