### PR TITLE
Check for null response before checking the status

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ Request.prototype.promise = function() {
 
   return new Promise(function(resolve, reject, onCancel) {
       req.end(function(err, res) {
-        if (typeof res !== "undefined" && res.status >= 400) {
+        if (typeof res !== "undefined" && res !== null && res.status >= 400) {
           var msg = 'cannot ' + req.method + ' ' + req.url + ' (' + res.status + ')';
           error = new SuperagentPromiseError(msg);
           error.status = res.status;


### PR DESCRIPTION
Fix for #64 

The current version of SuperAgent [calls the end callback with a null response whenever an error event is emitted](https://github.com/visionmedia/superagent/blob/e50a0fbe5c84ddf2b4baeb1a4340512b96a106ef/lib/node/index.js#L820).
This can for example happen if we try to decompress an empty response that was sent with a `Content-Encoding: gzip` header. The issue is very nasty, because the TypeError is thrown outside the control of the code using this library.

A simple truthiness check would probably be nicer, but I just went with the most straightforward fix, because I didn't have time to dig into the SuperAgent codebase and double-check that res is always a sensible response object if it's truthy.