### PR TITLE
Preserve original error.message when wrapping errors in SuperagentPromiseError

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ Request.prototype.promise = function() {
           error.res = res;
           reject(error);
         } else if (err) {
-          reject(new SuperagentPromiseError('Bad request', err));
+          reject(new SuperagentPromiseError(err.message, err));
         } else {
           resolve(res);
         }


### PR DESCRIPTION
Whenever something goes wrong inside superagent, the promise is rejected with SuperagentPromiseError that has rather uninformative .toString() "SuperagentPromiseError: Bad request".

This change preserves the original error message, so .toString() returns e.g. "SuperagentPromiseError: connect ECONNREFUSED 127.0.0.1:80".